### PR TITLE
Bugfix for issues #5 and #6

### DIFF
--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -100,7 +100,7 @@ endif()
 
 
 # Build engine as a dynamic library
-add_library(engine SHARED)
+add_library(engine SHARED "")
 set_target_properties(engine PROPERTIES VERSION 1.0.0 SOVERSION 1)
 
 # ImGui

--- a/Engine/src/Core/application.cpp
+++ b/Engine/src/Core/application.cpp
@@ -4,7 +4,9 @@
 
 #include <GLFW/glfw3.h>
 
+
 namespace Trundle {
+
     Application* Application::instance = nullptr;
 
     Application::Application() {


### PR DESCRIPTION
The build system is now treating header files like proper source files, giving
them full access to the includes list and watching them for changes and marking
them for rebuilding.